### PR TITLE
更换ai绘图模型

### DIFF
--- a/nonebot_plugin_chatglm_plus/__init__.py
+++ b/nonebot_plugin_chatglm_plus/__init__.py
@@ -637,8 +637,9 @@ async def req_draw(auth_token,arg):
         "Authorization": f"Bearer {auth_token}"
     }
     data = {
-    "model": "cogview-3",
-    "prompt": arg
+    "model": "cogview-3-plus",
+    "prompt": arg,
+    "size": "1344x768"
     }
     async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10, read=config.glm_timeout, write=20, pool=30)) as client:
         res = await client.post(draw_url, headers=headers, json=data)


### PR DESCRIPTION
切换至功能更强大的且价格更低廉的智谱清言模型
并且设置默认绘画输出结果为长方形（1344*768）的图片，替换掉之前的正方形图片输出模式。